### PR TITLE
fix: Add UTF-8 encoding for file reading

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ app = Flask(__name__)
 @app.route("/")
 def index():
 
-    with open("sucveceza.txt", "r") as file:
+    with open("sucveceza.txt", "r", encoding="utf8") as file:
         text = file.read()
 
     words = text.split()  # Split the text into words


### PR DESCRIPTION
Fix an issue where a UnicodeDecodeError was encountered during file reading. The fix involves adding UTF-8 encoding for file reading to handle the encoding properly.
